### PR TITLE
Update KubeArmor helm charts to use Scarf endpoint

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          repository: "kubearmor/KubeArmor"
+          repository: "kubearmor.docker.scarf.sh/kubearmor/kubearmor"
 
       - uses: azure/setup-helm@v3
         with:


### PR DESCRIPTION
@nyrahul @HighnessAtharva 

This change will update the KubeArmor helm charts to pull the kubearmor/kubearmor container image through the Scarf Docker endpoint. If desired, a custom domain can be used instead of the kubearmor.docker.scarf.sh domain in the future. The Scarf Gateway endpoints redirect to the existing Docker repository where the KubeArmor Docker images are currently being hosted. These changes were suggested in direct discussions with the maintainers of KubeArmor.