### PR TITLE
Revert "Update KubeArmor helm charts to use Scarf endpoint"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          repository: "kubearmor.docker.scarf.sh/kubearmor/kubearmor"
+          repository: "kubearmor/KubeArmor"
 
       - uses: azure/setup-helm@v3
         with:


### PR DESCRIPTION
Reverts kubearmor/charts#6. It looks like this update was the wrong update to make - we are intending to update the Docker image references in the helm charts but this PR was put up which mistakenly updates the GitHub action. Sorry for the confusion!

I will put up another PR here that updates the correct image reference